### PR TITLE
Fixed a-key bug on mobile 

### DIFF
--- a/cube.js
+++ b/cube.js
@@ -229,8 +229,7 @@ function checkKeyboardEventKey(eventKey, eventKeyCode) {
       changeView();
       break;
     case "a":
-      if (continueAnimation) break;
-      startAnimation();
+      !continueAnimation && startAnimation();
       break;
     case "A":
       stopAnimation();
@@ -269,5 +268,6 @@ document.querySelectorAll(".cube-turn").forEach((element) => {
 document.querySelector(".generate").onclick = generate;
 document.querySelector(".reset").onclick = resetColor;
 document.querySelector(".view").onclick = changeView;
-document.querySelector(".start-animation").onclick = startAnimation;
+document.querySelector(".start-animation").onclick = () =>
+  !continueAnimation && startAnimation();
 document.querySelector(".stop-animation").onclick = stopAnimation;


### PR DESCRIPTION
I used an expression instead of an if statement for checking continueAnimation this time.