### PR TITLE
Fix issue #22

### DIFF
--- a/cubeparts.css
+++ b/cubeparts.css
@@ -14,24 +14,48 @@
     border-radius: 0.01px;
 }
 
+.front {
+    transform-style: preserve-3d;
+}
+
 .front>div {
     background-color: rgb(0, 128, 0);
+}
+
+.back {
+    transform-style: preserve-3d;
 }
 
 .back>div {
     background-color: rgb(0, 0, 255);
 }
 
+.up {
+    transform-style: preserve-3d;
+}
+
 .up>div {
     background-color: rgb(255, 255, 255);
+}
+
+.down {
+    transform-style: preserve-3d;
 }
 
 .down>div {
     background-color: rgb(255, 255, 0);
 }
 
+.right {
+    transform-style: preserve-3d;
+}
+
 .right>div {
     background-color: rgb(255, 0, 0);
+}
+
+.left {
+    transform-style: preserve-3d;
 }
 
 .left>div {


### PR DESCRIPTION
The transform-style property is not inherited, it must be set for all faces of the cube.

Tested on Firefox 100.0 and Chrome 101.0.4951.64 on Pop!_OS 22.04.